### PR TITLE
Change the skinparam of the classdiagram? (suggestion)

### DIFF
--- a/uml/class_diagrams/class.plantuml
+++ b/uml/class_diagrams/class.plantuml
@@ -1,5 +1,11 @@
 @startuml classdiagram
 
+skinparam ClassAttributeIconSize 0
+skinparam CircledCharacterRadius 0
+skinparam CircledCharacterFontSize 0
+skinparam ClassFontStyle bold
+
+
 ' Storage
 class PlayerStorage {
   + AddBill(b: BillOfMaterial)


### PR DESCRIPTION
Maybe its just my taste, but i think the colorful circles in the classdiagrams are useless, and the characters better represent the visibility than colored squares. It's just a suggestion, not really important.

