### PR TITLE
Handle TP and Handle Robot

### DIFF
--- a/java/src/hu/holyoil/controller/AIController.java
+++ b/java/src/hu/holyoil/controller/AIController.java
@@ -252,36 +252,36 @@ public class AIController implements ISteppable {
 
         List<Asteroid> neighbouringAsteroids = teleportGate.GetHomeAsteroid().GetNeighbours();
 
-        if(teleportGate.GetIsCrazy()) {
-            if (!Main.isRandomEnabled) {
-                int i = 0;
-                while (i < neighbouringAsteroids.size() && neighbouringAsteroids.get(i).GetTeleporter() != null)
-                    i++;
-                if (i < neighbouringAsteroids.size())
-                    teleportGate.Move(neighbouringAsteroids.get(i));
 
-            } else {
-                Random random = new Random();
-                int chosenIndex = random.nextInt(neighbouringAsteroids.size());
-                int start = chosenIndex;
-                boolean canMove = true;
-                while (canMove && neighbouringAsteroids.get(chosenIndex).GetTeleporter() != null) {
-                    if (chosenIndex == neighbouringAsteroids.size() - 1) {
-                        chosenIndex = -1;
-                    }
-                    chosenIndex++;
-                    if (chosenIndex == start) {
-                        canMove = false;
-                    }
+        if (!Main.isRandomEnabled) {
+            int i = 0;
+            while (i < neighbouringAsteroids.size() && neighbouringAsteroids.get(i).GetTeleporter() != null)
+                i++;
+            if (i < neighbouringAsteroids.size())
+                teleportGate.Move(neighbouringAsteroids.get(i));
+
+        } else {
+            Random random = new Random();
+            int chosenIndex = random.nextInt(neighbouringAsteroids.size());
+            int start = chosenIndex;
+            boolean canMove = true;
+            while (canMove && neighbouringAsteroids.get(chosenIndex).GetTeleporter() != null) {
+                if (chosenIndex == neighbouringAsteroids.size() - 1) {
+                    chosenIndex = -1;
                 }
-                if (canMove) {
-                    teleportGate.Move(neighbouringAsteroids.get(chosenIndex));
-                } else {
-                    Logger.Log(this, "All neighbours already have a teleporter, cannot move");
-                    Logger.Return();
+                chosenIndex++;
+                if (chosenIndex == start) {
+                    canMove = false;
                 }
             }
+            if (canMove) {
+                teleportGate.Move(neighbouringAsteroids.get(chosenIndex));
+            } else {
+                Logger.Log(this, "All neighbours already have a teleporter, cannot move");
+                Logger.Return();
+            }
         }
+
         Logger.Return();
     }
 

--- a/java/src/hu/holyoil/controller/AIController.java
+++ b/java/src/hu/holyoil/controller/AIController.java
@@ -32,10 +32,7 @@ public class AIController implements ISteppable {
      * Az pályán található összes teleporter.
      */
     private List<TeleportGate> teleporters;
-    /**
-     * Az AI viselkedéséhez hozzájárló random tényező.
-     */
-    private Random random = new Random();
+
     /**
      * Minden robot végrehajt egy lépést
      * <p>Jelenleg nincs realizálva, teszteléshez nem szükséges.</p>
@@ -130,7 +127,7 @@ public class AIController implements ISteppable {
         else {
 
             List<Asteroid> neighbouringAsteroids = robot.GetOnAsteroid().GetNeighbours();
-            boolean tpAvailable = current.GetTeleporter() != null;
+            boolean tpAvailable = (current.GetTeleporter() != null && current.GetTeleporter().GetPair().GetHomeAsteroid()!=null);
             if (SunController.GetInstance().GetTurnsUntilStorm() < 2) {//sunstorm happens at the end of this or next turn
                 if (current.GetResource() == null && current.GetLayerCount() < 2) {//if current asteroid is empty and can be drilled, stay
                     robot.Drill(); //call Drill() even if it doesn't do anything to stay in place and simplicity
@@ -149,7 +146,7 @@ public class AIController implements ISteppable {
                         robot.Move(current.GetTeleporter());
                         Logger.Return();
                         return;
-                    } else {//look for a neighbour with a teleporter. maybe that will take the robto to an empty asteroid
+                    } else {//look for a neighbour with a teleporter. maybe that will take the robot to an empty asteroid
                         i = 0;
                         while (i < neighbouringAsteroids.size() && neighbouringAsteroids.get(i).GetTeleporter() != null)
                             i++;
@@ -168,7 +165,7 @@ public class AIController implements ISteppable {
                 Logger.Return();
                 return;
             }
-
+            Random random = new Random();
             Asteroid target;
             int chosenIndex = random.nextInt(neighbouringAsteroids.size());
             int start = chosenIndex;
@@ -255,35 +252,36 @@ public class AIController implements ISteppable {
 
         List<Asteroid> neighbouringAsteroids = teleportGate.GetHomeAsteroid().GetNeighbours();
 
-        if(!Main.isRandomEnabled){
-            int i=0;
-            while(i<neighbouringAsteroids.size() && neighbouringAsteroids.get(i).GetTeleporter()!=null)
-                i++;
-            if(i<neighbouringAsteroids.size())
-                teleportGate.Move(neighbouringAsteroids.get(i));
+        if(teleportGate.GetIsCrazy()) {
+            if (!Main.isRandomEnabled) {
+                int i = 0;
+                while (i < neighbouringAsteroids.size() && neighbouringAsteroids.get(i).GetTeleporter() != null)
+                    i++;
+                if (i < neighbouringAsteroids.size())
+                    teleportGate.Move(neighbouringAsteroids.get(i));
 
-        }
-        else {
-            int chosenIndex = random.nextInt(neighbouringAsteroids.size());
-            int start = chosenIndex;
-            boolean canMove = true;
-            while (canMove && neighbouringAsteroids.get(chosenIndex).GetTeleporter() != null) {
-                if (chosenIndex == neighbouringAsteroids.size() - 1) {
-                    chosenIndex = -1;
-                }
-                chosenIndex++;
-                if (chosenIndex == start) {
-                    canMove = false;
-                }
-            }
-            if (canMove) {
-                teleportGate.Move(neighbouringAsteroids.get(chosenIndex));
             } else {
-                Logger.Log(this, "All neighbours already have a teleporter, cannot move");
-                Logger.Return();
+                Random random = new Random();
+                int chosenIndex = random.nextInt(neighbouringAsteroids.size());
+                int start = chosenIndex;
+                boolean canMove = true;
+                while (canMove && neighbouringAsteroids.get(chosenIndex).GetTeleporter() != null) {
+                    if (chosenIndex == neighbouringAsteroids.size() - 1) {
+                        chosenIndex = -1;
+                    }
+                    chosenIndex++;
+                    if (chosenIndex == start) {
+                        canMove = false;
+                    }
+                }
+                if (canMove) {
+                    teleportGate.Move(neighbouringAsteroids.get(chosenIndex));
+                } else {
+                    Logger.Log(this, "All neighbours already have a teleporter, cannot move");
+                    Logger.Return();
+                }
             }
         }
-
         Logger.Return();
     }
 

--- a/java/src/hu/holyoil/controller/SunController.java
+++ b/java/src/hu/holyoil/controller/SunController.java
@@ -123,6 +123,10 @@ public class SunController implements ISteppable, IIdentifiable {
         Logger.Return();
     }
 
+    /**
+     * Visszaadja hány kör van még a következő napciharig.
+     * @return int, turnsUntilNextSunstorm
+     */
     public int GetTurnsUntilStorm(){
         Logger.Log(this, "Returning turns until next Sunstorm: " + turnsUntilNextSunstorm);
         Logger.Return();
@@ -130,7 +134,7 @@ public class SunController implements ISteppable, IIdentifiable {
     }
 
     /**
-     * Singleton osztályhoz való hozzáférés miatt kell
+     * Singleton osztályhoz való hozzáférés miatt kell.
      * @return visszaad egy instance-ot
      */
     public static SunController GetInstance() {
@@ -148,7 +152,7 @@ public class SunController implements ISteppable, IIdentifiable {
     }
 
     /**
-     * Privát konstruktor
+     * Privát konstruktor.
      * Nem lehet kívülről meghívni, nem lehet példányosítani.
      * <p>A 100 forduló a következő napviharig egy ad hoc szám, bármi lehet.
      * Inicializálja az aszteroidáka tároló listát.</p>

--- a/java/src/hu/holyoil/controller/SunController.java
+++ b/java/src/hu/holyoil/controller/SunController.java
@@ -123,6 +123,12 @@ public class SunController implements ISteppable, IIdentifiable {
         Logger.Return();
     }
 
+    public int GetTurnsUntilStorm(){
+        Logger.Log(this, "Returning turns until next Sunstorm: " + turnsUntilNextSunstorm);
+        Logger.Return();
+        return turnsUntilNextSunstorm;
+    }
+
     /**
      * Singleton osztályhoz való hozzáférés miatt kell
      * @return visszaad egy instance-ot

--- a/java/src/hu/holyoil/neighbour/Asteroid.java
+++ b/java/src/hu/holyoil/neighbour/Asteroid.java
@@ -366,7 +366,7 @@ public class Asteroid implements INeighbour {
         Logger.Return();
     }
 
-    private Random random = new Random();
+
 
     /**
      * Visszaad egy véletlen szomszédot.
@@ -403,7 +403,7 @@ public class Asteroid implements INeighbour {
                 return neighbouringAsteroids.get(0);
         }
         else {
-
+            Random random = new Random();
             boolean canChooseTeleporter = false;
             if (teleporter != null) {
                 if (teleporter.GetPair().GetHomeAsteroid() != null) {

--- a/java/src/hu/holyoil/neighbour/Asteroid.java
+++ b/java/src/hu/holyoil/neighbour/Asteroid.java
@@ -154,7 +154,6 @@ public class Asteroid implements INeighbour {
         if (teleporter == null) {
             comingTeleporter.GetHomeAsteroid().RemoveTeleporter();
             SetTeleporter(comingTeleporter);
-            comingTeleporter.GetHomeAsteroid().SetTeleporter(null);
             comingTeleporter.SetHomeAsteroid(this);
         }
         else {
@@ -195,6 +194,11 @@ public class Asteroid implements INeighbour {
         Logger.Return();
 
     }
+
+    /**
+     * Visszaadja napközeli-e az aszteroida
+     * @return boolean, true: napközeli, false: nem napközeli
+     */
     public boolean GetIsNearbySun(){
         Logger.Log(this, "isNearbySun: " + isNearSun.toString());
         Logger.Return();
@@ -362,6 +366,8 @@ public class Asteroid implements INeighbour {
         Logger.Return();
     }
 
+    private Random random = new Random();
+
     /**
      * Visszaad egy véletlen szomszédot.
      * <p>
@@ -398,7 +404,6 @@ public class Asteroid implements INeighbour {
         }
         else {
 
-            Random random = new Random();
             boolean canChooseTeleporter = false;
             if (teleporter != null) {
                 if (teleporter.GetPair().GetHomeAsteroid() != null) {
@@ -406,8 +411,7 @@ public class Asteroid implements INeighbour {
                 }
             }
 
-            int chosenIndex = random.nextInt() %
-                    (neighbouringAsteroids.size() + (canChooseTeleporter ? 0 : 1));
+            int chosenIndex = random.nextInt((neighbouringAsteroids.size() + (canChooseTeleporter ? 1 : 0)));
 
             return chosenIndex == neighbouringAsteroids.size() ?
                     teleporter :
@@ -579,6 +583,10 @@ public class Asteroid implements INeighbour {
 
     }
 
+    /**
+     * Beállítja az új felfedezettséget
+     * @param newIsDiscovered az isDiscovered új értéke
+     */
     public void SetIsDiscovered(Boolean newIsDiscovered) {
 
         isDiscovered = newIsDiscovered;

--- a/java/src/hu/holyoil/neighbour/Asteroid.java
+++ b/java/src/hu/holyoil/neighbour/Asteroid.java
@@ -146,7 +146,7 @@ public class Asteroid implements INeighbour {
 
     /**
      * Mozgatja a kapott teleportert erre az aszteroidára.
-     * @param comingTeleporter ide a mozgást elvégezni készülő Spaceship
+     * @param comingTeleporter az ide mozgást elvégezni készülő teleporter
      */
     public void ReactToMove(TeleportGate comingTeleporter){
         Logger.Log(this, "Reacting to coming teleporter: " + Logger.GetName(comingTeleporter));
@@ -154,6 +154,7 @@ public class Asteroid implements INeighbour {
         if (teleporter == null) {
             comingTeleporter.GetHomeAsteroid().RemoveTeleporter();
             SetTeleporter(comingTeleporter);
+            comingTeleporter.GetHomeAsteroid().SetTeleporter(null);
             comingTeleporter.SetHomeAsteroid(this);
         }
         else {
@@ -193,6 +194,11 @@ public class Asteroid implements INeighbour {
         isNearSun = newIsNearbySun;
         Logger.Return();
 
+    }
+    public boolean GetIsNearbySun(){
+        Logger.Log(this, "isNearbySun: " + isNearSun.toString());
+        Logger.Return();
+        return isNearSun;
     }
 
     /**

--- a/java/src/hu/holyoil/neighbour/TeleportGate.java
+++ b/java/src/hu/holyoil/neighbour/TeleportGate.java
@@ -85,6 +85,16 @@ public class TeleportGate implements INeighbour {
     }
 
     /**
+     * Visszaadja a teleporter kerge állapotát.
+     * @return true: már érte napvihar, false: még nem érte napvihar
+     */
+    public boolean GetIsCrazy(){
+        Logger.Log(this, "Returning teleport craziness: " + isCrazy);
+        Logger.Return();
+        return isCrazy;
+    }
+
+    /**
      * Visszaadja az aszteroidát amin a teleporter található.
      * @return a teleporter homeAsteroid tagváltozója
      */

--- a/java/testdir/trialin_robot_randomly_moves.txt
+++ b/java/testdir/trialin_robot_randomly_moves.txt
@@ -1,4 +1,4 @@
-echo_off
+
 
 
 create asteroid a1 0 false
@@ -29,7 +29,7 @@ add_neighbour a4 a5
 add_neighbour a4 a6
 add_neighbour a5 a6
 
-create settler s1 a1
+create settler s1 a6
 create storage storage1 s1
 create teleportpair t1 t2 storage1 storage1
 

--- a/java/testdir/trialin_robot_randomly_moves.txt
+++ b/java/testdir/trialin_robot_randomly_moves.txt
@@ -1,0 +1,46 @@
+echo_off
+
+
+create asteroid a1 0 false
+create asteroid a2 0 true
+create asteroid a3 0 false
+create asteroid a4 0 false
+create asteroid a5 0 true
+create asteroid a6 0
+
+create uranium u1 a2
+create water w1 a6
+create coal c1 a4
+create iron i1 a5
+
+add_neighbour a1 a2
+add_neighbour a1 a3
+add_neighbour a1 a4
+add_neighbour a1 a5
+add_neighbour a1 a6
+add_neighbour a2 a3
+add_neighbour a2 a4
+add_neighbour a2 a5
+add_neighbour a2 a6
+add_neighbour a3 a4
+add_neighbour a3 a5
+add_neighbour a3 a6
+add_neighbour a4 a5
+add_neighbour a4 a6
+add_neighbour a5 a6
+
+create settler s1 a1
+create storage storage1 s1
+create teleportpair t1 t2 storage1 storage1
+
+create robot r1 a6
+
+do s1 placeteleportgate
+step
+do s1 move a2
+step
+do s1 placeteleportgate
+step
+
+state
+exit

--- a/java/testdir/trialin_robot_randomly_moves_teleporters.txt
+++ b/java/testdir/trialin_robot_randomly_moves_teleporters.txt
@@ -1,4 +1,4 @@
-echo_off
+
 
 
 create asteroid a1 0 false
@@ -29,8 +29,17 @@ add_neighbour a4 a5
 add_neighbour a4 a6
 add_neighbour a5 a6
 
+create settler s1 a6
+create storage storage1 s1
+create teleportpair t1 t2 storage1 storage1
+
 create robot r1 a6
 
+do s1 placeteleportgate
+step
+do s1 move a2
+step
+do s1 placeteleportgate
 step
 
 state

--- a/java/testdir/trialin_robot_steps_twice.txt
+++ b/java/testdir/trialin_robot_steps_twice.txt
@@ -1,0 +1,39 @@
+echo_off
+
+
+create asteroid a1 5
+create asteroid a2 1 true
+create asteroid a3 1 false
+create asteroid a4 4 false
+create asteroid a5 1 true
+create asteroid a6 0
+
+create uranium u1 a2
+create water w1 a6
+create coal c1 a4
+create iron i1 a5
+
+add_neighbour a1 a2
+add_neighbour a1 a3
+add_neighbour a1 a4
+add_neighbour a1 a5
+add_neighbour a1 a6
+add_neighbour a2 a3
+add_neighbour a2 a4
+add_neighbour a2 a5
+add_neighbour a2 a6
+add_neighbour a3 a4
+add_neighbour a3 a5
+add_neighbour a3 a6
+add_neighbour a4 a5
+add_neighbour a4 a6
+add_neighbour a5 a6
+
+
+create robot r1 a6
+
+step
+step
+
+state
+exit

--- a/java/testdir/trialin_tpmoves_randomly.txt
+++ b/java/testdir/trialin_tpmoves_randomly.txt
@@ -1,0 +1,26 @@
+echo_off
+
+create asteroid a1
+create asteroid a2
+create asteroid a3
+create asteroid a4
+create asteroid a5
+create asteroid a6
+create settler s1 a1
+create storage storage1 s1
+create teleportpair t1 t2 storage1 storage1
+add_neighbour a1 a2
+add_neighbour a2 a3
+add_neighbour a1 a3
+add_neighbour a3 a4
+add_neighbour a1 a4
+add_neighbour a4 a5
+add_neighbour a1 a5
+add_neighbour a5 a6
+add_neighbour a1 a6
+do s1 placeteleportgate
+step
+do s1 move a2
+cause_sunstorm a1
+step
+state

--- a/java/testdir/trialout_robot_steps_twice.txt
+++ b/java/testdir/trialout_robot_steps_twice.txt
@@ -1,0 +1,58 @@
+ASTEROID (name:) a1
+	(is near sun:) false
+	(layers left:) 5
+	(is discovered:) false
+	(resource name:) null
+	(teleporter name:) null
+	(spaceship names:) []
+	(neighbour asteroid names:) [a2 a3 a4 a5 a6]
+ASTEROID (name:) a2
+	(is near sun:) true
+	(layers left:) 1
+	(is discovered:) false
+	(resource name:) u1
+	(teleporter name:) null
+	(spaceship names:) []
+	(neighbour asteroid names:) [a1 a3 a4 a5 a6]
+ASTEROID (name:) a3
+	(is near sun:) false
+	(layers left:) 1
+	(is discovered:) false
+	(resource name:) null
+	(teleporter name:) null
+	(spaceship names:) []
+	(neighbour asteroid names:) [a1 a2 a4 a5 a6]
+ASTEROID (name:) a4
+	(is near sun:) false
+	(layers left:) 3
+	(is discovered:) true
+	(resource name:) c1
+	(teleporter name:) null
+	(spaceship names:) [r1]
+	(neighbour asteroid names:) [a1 a2 a3 a5 a6]
+ASTEROID (name:) a5
+	(is near sun:) true
+	(layers left:) 1
+	(is discovered:) false
+	(resource name:) i1
+	(teleporter name:) null
+	(spaceship names:) []
+	(neighbour asteroid names:) [a1 a2 a3 a4 a6]
+ASTEROID (name:) a6
+	(is near sun:) false
+	(layers left:) 0
+	(is discovered:) false
+	(resource name:) w1
+	(teleporter name:) null
+	(spaceship names:) []
+	(neighbour asteroid names:) [a1 a2 a3 a4 a5]
+IRON (name:) i1
+WATER (name:) w1
+URANIUM (name:) u1
+	(health:) 3
+COAL (name:) c1
+ROBOT (name:) r1
+	(asteroid name:) a4
+SUNCONTROLLER (name:) SunController
+	(turns until next sunstorm:) 40
+LOST GAME


### PR DESCRIPTION
Mostly tested, should work.
Fixed some minor bugs in prev. code like Asteroid.GetRandomNeighbour.
BUG: Step calls HandleTeleportGate twice. Technically the result is still moving to a random neighbour, but this way it's possible to stay in place. (If the second random asteroid was the original.)
The new test files are labeled trialin_* and there is one trialout_* for when a robot moves  in a specific asteroid field, since that testcase is deterministic, because robots now have priorities. (It will always choose a4, as that is the only right option.) For priorities of robot, see javadoc of AIController.HandleRobot. 
Robot in coming sunstorm untested, but they should hide now. 
closes #256 